### PR TITLE
[GPZH-28] Sites.php Konfiguration für Multi-Site Setup

### DIFF
--- a/config/sites/erlenbach/.gitkeep
+++ b/config/sites/erlenbach/.gitkeep
@@ -1,0 +1,1 @@
+# Config sync directory for Erlenbach site

--- a/config/sites/thalheim/.gitkeep
+++ b/config/sites/thalheim/.gitkeep
@@ -1,0 +1,1 @@
+# Config sync directory for Thalheim site

--- a/config/sites/thalwil/.gitkeep
+++ b/config/sites/thalwil/.gitkeep
@@ -1,0 +1,1 @@
+# Config sync directory for Thalwil site

--- a/web/sites/erlenbach/.gitkeep
+++ b/web/sites/erlenbach/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for erlenbach site directory

--- a/web/sites/erlenbach/settings.php
+++ b/web/sites/erlenbach/settings.php
@@ -1,0 +1,50 @@
+<?php
+
+// @codingStandardsIgnoreFile
+
+/**
+ * @file
+ * Drupal site-specific configuration file for Erlenbach.
+ * 
+ * GPZH-28: Multi-Site Setup für Gemeinde Erlenbach
+ * Seegemeinde an der Goldküste
+ */
+
+// Site-specific config sync directory.
+$settings['config_sync_directory'] = '../config/sites/erlenbach';
+
+// Hash salt.
+$settings['hash_salt'] = getenv('DRUPAL_HASH_SALT');
+
+// Disallow access to update.php by anonymous users.
+$settings['update_free_access'] = FALSE;
+
+// Other helpful settings.
+$settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
+$settings['entity_update_batch_size'] = 50;
+$settings['file_scan_ignore_directories'] = [
+  'node_modules',
+  'bower_components',
+];
+
+// Site-specific database connection for Erlenbach.
+$databases['default']['default'] = [
+  'database' => getenv('DRUPAL_DATABASE_NAME') ?: 'db_erlenbach',
+  'username' => getenv('DRUPAL_DATABASE_USERNAME') ?: 'db',
+  'password' => getenv('DRUPAL_DATABASE_PASSWORD') ?: 'db',
+  'prefix' => '',
+  'host' => getenv('DRUPAL_DATABASE_HOST') ?: 'db',
+  'port' => getenv('DRUPAL_DATABASE_PORT') ?: '3306',
+  'namespace' => 'Drupal\Core\Database\Driver\mysql',
+  'driver' => 'mysql',
+];
+
+// Site-specific file paths.
+$settings['file_public_path'] = 'sites/erlenbach/files';
+$settings['file_private_path'] = 'sites/erlenbach/private';
+$settings['file_temp_path'] = 'sites/erlenbach/temp';
+
+// Include local settings if available.
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
+}

--- a/web/sites/sites.php
+++ b/web/sites/sites.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file
+ * Multi-Site Konfiguration für GPZH Demo
+ * Mappt Domains zu Site-Verzeichnissen
+ * 
+ * Epic: GPZH-27 - Multi-Site Drupal Setup für 3 Gemeinden
+ * Story: GPZH-28 - Sites.php Konfiguration für Multi-Site Setup
+ */
+
+$sites = [
+  // Thalwil - Moderne Stadtgemeinde
+  'thalwil.zh-demo.ddev.site' => 'thalwil',
+  'thalwil.adesso-cms.ddev.site' => 'thalwil',
+  
+  // Thalheim - Kleine Landgemeinde im Weinland
+  'thalheim.zh-demo.ddev.site' => 'thalheim',
+  'thalheim.adesso-cms.ddev.site' => 'thalheim',
+  
+  // Erlenbach - Seegemeinde an der Goldküste
+  'erlenbach.zh-demo.ddev.site' => 'erlenbach',
+  'erlenbach.adesso-cms.ddev.site' => 'erlenbach',
+  
+  // Default bleibt für Admin-Zugriff
+  'zh-demo.ddev.site' => 'default',
+  'adesso-cms.ddev.site' => 'default',
+];

--- a/web/sites/thalheim/.gitkeep
+++ b/web/sites/thalheim/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for thalheim site directory

--- a/web/sites/thalheim/settings.php
+++ b/web/sites/thalheim/settings.php
@@ -1,0 +1,50 @@
+<?php
+
+// @codingStandardsIgnoreFile
+
+/**
+ * @file
+ * Drupal site-specific configuration file for Thalheim.
+ * 
+ * GPZH-28: Multi-Site Setup für Gemeinde Thalheim
+ * Kleine Landgemeinde im Weinland
+ */
+
+// Site-specific config sync directory.
+$settings['config_sync_directory'] = '../config/sites/thalheim';
+
+// Hash salt.
+$settings['hash_salt'] = getenv('DRUPAL_HASH_SALT');
+
+// Disallow access to update.php by anonymous users.
+$settings['update_free_access'] = FALSE;
+
+// Other helpful settings.
+$settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
+$settings['entity_update_batch_size'] = 50;
+$settings['file_scan_ignore_directories'] = [
+  'node_modules',
+  'bower_components',
+];
+
+// Site-specific database connection for Thalheim.
+$databases['default']['default'] = [
+  'database' => getenv('DRUPAL_DATABASE_NAME') ?: 'db_thalheim',
+  'username' => getenv('DRUPAL_DATABASE_USERNAME') ?: 'db',
+  'password' => getenv('DRUPAL_DATABASE_PASSWORD') ?: 'db',
+  'prefix' => '',
+  'host' => getenv('DRUPAL_DATABASE_HOST') ?: 'db',
+  'port' => getenv('DRUPAL_DATABASE_PORT') ?: '3306',
+  'namespace' => 'Drupal\Core\Database\Driver\mysql',
+  'driver' => 'mysql',
+];
+
+// Site-specific file paths.
+$settings['file_public_path'] = 'sites/thalheim/files';
+$settings['file_private_path'] = 'sites/thalheim/private';
+$settings['file_temp_path'] = 'sites/thalheim/temp';
+
+// Include local settings if available.
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
+}

--- a/web/sites/thalwil/.gitkeep
+++ b/web/sites/thalwil/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for thalwil site directory

--- a/web/sites/thalwil/settings.php
+++ b/web/sites/thalwil/settings.php
@@ -1,0 +1,50 @@
+<?php
+
+// @codingStandardsIgnoreFile
+
+/**
+ * @file
+ * Drupal site-specific configuration file for Thalwil.
+ * 
+ * GPZH-28: Multi-Site Setup für Gemeinde Thalwil
+ * Moderne Stadtgemeinde am Zürichsee
+ */
+
+// Site-specific config sync directory.
+$settings['config_sync_directory'] = '../config/sites/thalwil';
+
+// Hash salt.
+$settings['hash_salt'] = getenv('DRUPAL_HASH_SALT');
+
+// Disallow access to update.php by anonymous users.
+$settings['update_free_access'] = FALSE;
+
+// Other helpful settings.
+$settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
+$settings['entity_update_batch_size'] = 50;
+$settings['file_scan_ignore_directories'] = [
+  'node_modules',
+  'bower_components',
+];
+
+// Site-specific database connection for Thalwil.
+$databases['default']['default'] = [
+  'database' => getenv('DRUPAL_DATABASE_NAME') ?: 'db_thalwil',
+  'username' => getenv('DRUPAL_DATABASE_USERNAME') ?: 'db',
+  'password' => getenv('DRUPAL_DATABASE_PASSWORD') ?: 'db',
+  'prefix' => '',
+  'host' => getenv('DRUPAL_DATABASE_HOST') ?: 'db',
+  'port' => getenv('DRUPAL_DATABASE_PORT') ?: '3306',
+  'namespace' => 'Drupal\Core\Database\Driver\mysql',
+  'driver' => 'mysql',
+];
+
+// Site-specific file paths.
+$settings['file_public_path'] = 'sites/thalwil/files';
+$settings['file_private_path'] = 'sites/thalwil/private';
+$settings['file_temp_path'] = 'sites/thalwil/temp';
+
+// Include local settings if available.
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
+}


### PR DESCRIPTION
## 🎯 Jira Ticket: [GPZH-28](https://adesso-app-mgt.atlassian.net/browse/GPZH-28)
Part of Epic: [GPZH-27](https://adesso-app-mgt.atlassian.net/browse/GPZH-27)

## 📋 Summary
Implementiert die grundlegende Multi-Site Konfiguration für 3 Gemeinden (Thalwil, Thalheim, Erlenbach) mit gemeinsamer Drupal-Installation.

## ✅ Akzeptanzkriterien (aus Jira)
- ✅ sites.php existiert mit korrekten Domain-Mappings
- ✅ Alle 3 Site-Verzeichnisse angelegt (thalwil, thalheim, erlenbach)
- ✅ Jede Site hat eigene settings.php
- ✅ Config-Sync Verzeichnisse definiert
- ✅ File-Verzeichnisse haben korrekte Berechtigungen

## 🔧 Implementierung
- Created `/web/sites/sites.php` with domain mappings for all 3 municipalities
- Set up site directories: `/web/sites/thalwil/`, `/web/sites/thalheim/`, `/web/sites/erlenbach/`
- Configured individual settings.php files with proper config sync paths
- Proper permissions (755) applied to all directories

## 📝 Test-Evidenz
```bash
# Verifizierte Struktur:
✓ /web/sites/sites.php (790 bytes)
✓ /web/sites/thalwil/ (with settings.php)
✓ /web/sites/thalheim/ (with settings.php)
✓ /web/sites/erlenbach/ (with settings.php)
```

## 🏷️ Labels
- backend
- configuration
- multi-site

## 📊 Story Points: 3

## Review Request
@claude Please verify that the multi-site configuration follows Drupal 11 best practices and that all acceptance criteria from GPZH-28 are met.

🤖 Generated with Claude Code